### PR TITLE
feat: add boolean assignment support

### DIFF
--- a/Evaluator.cpp
+++ b/Evaluator.cpp
@@ -66,6 +66,10 @@ string Evaluator::evaluateAssignment(const ASTNode &node)
     {
         setVariableValue(identifier, node.children[1].value, "STRING");
     }
+    else if (node.children[1].type == "BOOL")
+    {
+        setVariableValue(identifier, node.children[1].value, "BOOL");
+    }
     else
     {
         string value = evaluateExpression(node.children[1]);


### PR DESCRIPTION
Adds support for assigning boolean values to variables. This commit extends the evaluator to handle boolean assignments in addition to existing string assignments.