### PR TITLE
Refactor: Implement data type validation for assignment statements

### DIFF
--- a/Parser.cpp
+++ b/Parser.cpp
@@ -50,35 +50,6 @@ ASTNode Parser::parse()
  * @return An Abstract Syntax Tree node representing the assignment statement.
  */
 
-// ASTNode Parser::parseAssignment()
-// {
-//     Token identifier = consume("IDENTIFIER");
-//     ASTNode assignment("ASSIGNMENT");
-
-//     ASTNode identifierNode("IDENTIFIER", identifier.value);
-
-//     if (peek().type == "COLON")
-//     {
-//         consume("COLON");
-//         Token typ = consume("TYPE");
-//         ASTNode datatype("TYPE",typ.value);
-//         identifierNode.children.push_back(datatype);
-//     }
-
-//     assignment.children.push_back(identifierNode);
-
-//     consume("ASSIGN");
-
-//     // Wraping arithmetic expressions inside an EXPRESSION node
-//     ASTNode expressionNode = parseExpression(); // parseExpression() in func/parseExpression/parseExpression.cpp
-//     assignment.children.push_back(expressionNode);
-
-//     consume("SEMICOLON");
-//     consume("LINE_BREAK");
-
-//     return assignment;
-// }
-
 ASTNode Parser::parseAssignment()
 {
     Token identifier = consume("IDENTIFIER");
@@ -99,7 +70,7 @@ ASTNode Parser::parseAssignment()
 
         // Wraping arithmetic expressions inside an EXPRESSION node
         ASTNode expressionNode = parseExpression(); // parseExpression() in func/parseExpression/parseExpression.cpp
-        if (ValidateDataType(identifierNode,expressionNode))
+        if (ValidateDataType(identifierNode, expressionNode))
         {
             assignment.children.push_back(expressionNode);
             consume("SEMICOLON");
@@ -124,7 +95,6 @@ ASTNode Parser::parseAssignment()
 
         consume("SEMICOLON");
         consume("LINE_BREAK");
-
     }
     return assignment;
 }

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -50,6 +50,35 @@ ASTNode Parser::parse()
  * @return An Abstract Syntax Tree node representing the assignment statement.
  */
 
+// ASTNode Parser::parseAssignment()
+// {
+//     Token identifier = consume("IDENTIFIER");
+//     ASTNode assignment("ASSIGNMENT");
+
+//     ASTNode identifierNode("IDENTIFIER", identifier.value);
+
+//     if (peek().type == "COLON")
+//     {
+//         consume("COLON");
+//         Token typ = consume("TYPE");
+//         ASTNode datatype("TYPE",typ.value);
+//         identifierNode.children.push_back(datatype);
+//     }
+
+//     assignment.children.push_back(identifierNode);
+
+//     consume("ASSIGN");
+
+//     // Wraping arithmetic expressions inside an EXPRESSION node
+//     ASTNode expressionNode = parseExpression(); // parseExpression() in func/parseExpression/parseExpression.cpp
+//     assignment.children.push_back(expressionNode);
+
+//     consume("SEMICOLON");
+//     consume("LINE_BREAK");
+
+//     return assignment;
+// }
+
 ASTNode Parser::parseAssignment()
 {
     Token identifier = consume("IDENTIFIER");
@@ -61,21 +90,42 @@ ASTNode Parser::parseAssignment()
     {
         consume("COLON");
         Token type = consume("TYPE");
-        ASTNode datatype(type.type,type.value);
+        ASTNode datatype(type.type, type.value);
         identifierNode.children.push_back(datatype);
+
+        assignment.children.push_back(identifierNode);
+
+        consume("ASSIGN");
+
+        // Wraping arithmetic expressions inside an EXPRESSION node
+        ASTNode expressionNode = parseExpression(); // parseExpression() in func/parseExpression/parseExpression.cpp
+        if (ValidateDataType(identifierNode,expressionNode))
+        {
+            assignment.children.push_back(expressionNode);
+            consume("SEMICOLON");
+            consume("LINE_BREAK");
+
+            return assignment;
+        }
+        else
+            throw runtime_error("Unexpected type: Declared " + identifierNode.children[0].value + " but got " + expressionNode.type);
     }
 
-    assignment.children.push_back(identifierNode);
+    else
+    {
 
-    consume("ASSIGN");
+        assignment.children.push_back(identifierNode);
 
-    // Wraping arithmetic expressions inside an EXPRESSION node
-    ASTNode expressionNode = parseExpression(); // parseExpression() in func/parseExpression/parseExpression.cpp
-    assignment.children.push_back(expressionNode);
+        consume("ASSIGN");
 
-    consume("SEMICOLON");
-    consume("LINE_BREAK");
+        // Wraping arithmetic expressions inside an EXPRESSION node
+        ASTNode expressionNode = parseExpression(); // parseExpression() in func/parseExpression/parseExpression.cpp
+        assignment.children.push_back(expressionNode);
 
+        consume("SEMICOLON");
+        consume("LINE_BREAK");
+
+    }
     return assignment;
 }
 

--- a/Parser.h
+++ b/Parser.h
@@ -23,8 +23,8 @@ private:
     Token consume(const string &expectedType);
 
     int getPrecedence(const string &op);
-    
-    bool ValidateDataType(const ASTNode& node1,const ASTNode& node2);
+
+    bool ValidateDataType(const ASTNode &node1, const ASTNode &node2);
 
     ASTNode parseExpression(int minimumPrecedence = 0);
 

--- a/Parser.h
+++ b/Parser.h
@@ -23,6 +23,8 @@ private:
     Token consume(const string &expectedType);
 
     int getPrecedence(const string &op);
+    
+    bool ValidateDataType(const ASTNode& node1,const ASTNode& node2);
 
     ASTNode parseExpression(int minimumPrecedence = 0);
 

--- a/func/ValidateDataType/ValidateDataType.cpp
+++ b/func/ValidateDataType/ValidateDataType.cpp
@@ -1,31 +1,43 @@
 #include "../../Parser.h"
 using namespace std;
 
-bool Parser::ValidateDataType(const ASTNode& node1,const ASTNode& node2){
+/**
+ * This function validates the declared datatype with the assigned value type.
+ * @param node1 which is the value of child node TYPE in Identifier
+ * @param node2 which is the node type of the value assigned
+ * @return true if the declared type matches with the assigned value type, otherwise false
+ */
+
+bool Parser::ValidateDataType(const ASTNode &node1, const ASTNode &node2)
+{
     if ((node1.children[0].value == "int") && (node2.type == "INTEGER"))
     {
         return true;
     }
-    else if ((node1.children[0].value == "bool") && (node2.type == "BOOL")){
+    else if ((node1.children[0].value == "bool") && (node2.type == "BOOL"))
+    {
         return true;
     }
-    else if ((node1.children[0].value == "double") && (node2.type == "DOUBLE")){
+    else if ((node1.children[0].value == "double") && (node2.type == "DOUBLE"))
+    {
         return true;
     }
-    else if ((node1.children[0].value == "string") && (node2.type == "STRING")){
+    else if ((node1.children[0].value == "string") && (node2.type == "STRING"))
+    {
         return true;
     }
-    else if ((node1.children[0].value == "char") && (node2.type == "CHAR")){
+    else if ((node1.children[0].value == "char") && (node2.type == "CHAR"))
+    {
         return true;
     }
-    else if ((node1.children[0].value == "float") && (node2.type == "FLOAT")){
+    else if ((node1.children[0].value == "float") && (node2.type == "FLOAT"))
+    {
         return true;
     }
-    else if ((node1.children[0].value == "long") && (node2.type == "LONG")){
+    else if ((node1.children[0].value == "long") && (node2.type == "LONG"))
+    {
         return true;
     }
     else
         return false;
 }
-
-

--- a/func/ValidateDataType/ValidateDataType.cpp
+++ b/func/ValidateDataType/ValidateDataType.cpp
@@ -1,0 +1,31 @@
+#include "../../Parser.h"
+using namespace std;
+
+bool Parser::ValidateDataType(const ASTNode& node1,const ASTNode& node2){
+    if ((node1.children[0].value == "int") && (node2.type == "INTEGER"))
+    {
+        return true;
+    }
+    else if ((node1.children[0].value == "bool") && (node2.type == "BOOL")){
+        return true;
+    }
+    else if ((node1.children[0].value == "double") && (node2.type == "DOUBLE")){
+        return true;
+    }
+    else if ((node1.children[0].value == "string") && (node2.type == "STRING")){
+        return true;
+    }
+    else if ((node1.children[0].value == "char") && (node2.type == "CHAR")){
+        return true;
+    }
+    else if ((node1.children[0].value == "float") && (node2.type == "FLOAT")){
+        return true;
+    }
+    else if ((node1.children[0].value == "long") && (node2.type == "LONG")){
+        return true;
+    }
+    else
+        return false;
+}
+
+

--- a/func/parseTerm/parseTerm.cpp
+++ b/func/parseTerm/parseTerm.cpp
@@ -22,7 +22,7 @@ ASTNode Parser::parseTerm()
         return expr;
     }
 
-    if (token.type == "INTEGER" || token.type == "FLOAT" || token.type == "DOUBLE" || token.type == "STRING" || token.type == "BOOL" || token.type == "CHAR")
+    if (token.type == "INTEGER" || token.type == "FLOAT" || token.type == "DOUBLE" || token.type == "STRING" || token.type == "BOOL" || token.type == "CHAR" || token.type == "LONG")
     {
         return ASTNode(token.type, consume(token.type).value);
     }


### PR DESCRIPTION
This commit refactors the `parseAssignment` function to include data type validation. It introduces a `ValidateDataType` function that checks if the assigned value's type matches the declared type of the identifier. If a mismatch is detected, a runtime error is thrown.

The changes include:

- Re-implement the logic inside `parseAssignment` to incorporate data type validation when a type is specified for the identifier.
- Add `ValidateDataType` function in `func/ValidateDataType/ValidateDataType.cpp` to perform the type checking.
- Support `long` type in parseTerm function.