### PR TITLE
Refactor: Add RangeType node to for loop AST

### DIFF
--- a/Parser.cpp
+++ b/Parser.cpp
@@ -278,6 +278,8 @@ ASTNode Parser::parseForLoop()
     if (range_type.type == "TO" || range_type.type == "DOWNTO" || range_type.type == "DOWNUNTIL" || range_type.type == "UNTIL")
     {
         consume(range_type.type);
+        ASTNode RangeType(range_type.type);
+        rangeNode.children.push_back(RangeType);
     }
     else
     {


### PR DESCRIPTION
Adds the RangeType token to the for loop AST as a child of the rangeNode. This provides more comprehensive information in the generated AST for for loops.