### PR TITLE
Refactor: Move RETURN parsing into the main loop of parseBody

### DIFF
--- a/Parser.cpp
+++ b/Parser.cpp
@@ -154,6 +154,7 @@ ASTNode Parser::parseIfStatement()
     ASTNode ifNode("IF");
     ASTNode condition = parseCondition(); // parseCondition() in func/parseCondition/parseCondition.cpp
     ifNode.children.push_back(condition);
+    insideFunction = false;
     ASTNode body = parseBody(); // parseBody() in func/parseBody/parseBody.cpp
     ifNode.children.push_back(body);
     ifStatement.children.push_back(ifNode);
@@ -164,6 +165,7 @@ ASTNode Parser::parseIfStatement()
         ASTNode elseIfNode("ELSE IF");
         ASTNode condition = parseCondition(); // parseCondition() in func/parseCondition/parseCondition.cpp
         elseIfNode.children.push_back(condition);
+        insideFunction = false;
         ASTNode body = parseBody(); // parseBody() in func/parseBody/parseBody.cpp
         elseIfNode.children.push_back(body);
         ifStatement.children.push_back(elseIfNode);
@@ -173,6 +175,7 @@ ASTNode Parser::parseIfStatement()
     {
         consume("ELSE");
         ASTNode elseNode("ELSE");
+        insideFunction = false;
         ASTNode body = parseBody(); // parseBody() in func/parseBody/parseBody.cpp
         elseNode.children.push_back(body);
         ifStatement.children.push_back(elseNode);
@@ -198,6 +201,7 @@ ASTNode Parser::parseWhileLoop()
     ASTNode whileNode("WHILE");
     ASTNode condition = parseCondition(); // parseCondition() in func/parseCondition/parseCondition.cpp
     whileNode.children.push_back(condition);
+    insideFunction = false;
     ASTNode body = parseBody(); // parseBody() in func/parseBody/parseBody.cpp
     whileNode.children.push_back(body);
     return whileNode;
@@ -306,13 +310,14 @@ ASTNode Parser::parseForLoop()
     }
     consume("CLOSE_ROUND_BRACKET");
 
+    insideFunction = false;
     ASTNode body = parseBody(); // parseBody() in func/parseBody/ParseBody.cpp
     ForNode.children.push_back(body);
 
     return ForNode;
 }
 ASTNode Parser::parseFunction()
-{
+{   
     consume("FUNCTION");
 
     ASTNode Function("FUNCTION");
@@ -349,6 +354,7 @@ ASTNode Parser::parseFunction()
     Function.children.push_back(Parameters);
 
     // Function body
+    insideFunction = true;
     ASTNode parseFunctionBody = parseBody();
     Function.children.push_back(parseFunctionBody);
 

--- a/Parser.h
+++ b/Parser.h
@@ -17,6 +17,7 @@ public:
 private:
     vector<Token> tokens;
     size_t currentIndex;
+    bool insideFunction;
 
     Token peek();
 

--- a/func/parseBody/parseBody.cpp
+++ b/func/parseBody/parseBody.cpp
@@ -1,4 +1,5 @@
 #include "../../Parser.h"
+#include<iostream>
 
 /**
  * @return An AST node representing the body of a block
@@ -30,11 +31,19 @@
          }
          else if (peek().type == "RETURN")
          {
-             consume("RETURN");
-             ASTNode Return("RETURN");
-             ASTNode returnExpression = parseExpression();
-             Return.children.push_back(returnExpression);
-             body.children.push_back(Return);
+            if(insideFunction){
+
+                consume("RETURN");
+                ASTNode Return("RETURN");
+                ASTNode returnExpression = parseExpression();
+                Return.children.push_back(returnExpression);
+                body.children.push_back(Return);
+                consume("SEMICOLON");
+            }
+            else{
+                throw runtime_error("return only allowed in functions");
+                
+            }
          }
          else
          {

--- a/func/parseBody/parseBody.cpp
+++ b/func/parseBody/parseBody.cpp
@@ -12,43 +12,44 @@
  * the constructed BODY node.
  */
 
-ASTNode Parser::parseBody()
-{
-    while (peek().type == "LINE_BREAK")
-    {
-        consume("LINE_BREAK");
-    }
-
-    consume("OPEN_CURLY_BRACKET");
-    ASTNode body("BODY");
-
-    while (peek().type != "CLOSE_CURLY_BRACKET")
-    {
-        if (peek().type == "LINE_BREAK")
-        {
-            consume("LINE_BREAK");
-        }
-        else
-        {
-            ASTNode statement = parseStatement();
-            body.children.push_back(statement);
-        }
-    }
-    if (peek().type == "RETURN")
-    {
-        consume("RETURN");
-        ASTNode Return("RETURN");
-        ASTNode returnExpression = parseExpression();
-        Return.children.push_back(returnExpression);
-        body.children.push_back(Return);
-    }
-
-    consume("CLOSE_CURLY_BRACKET");
-
-    while (peek().type == "LINE_BREAK")
-    {
-        consume("LINE_BREAK");
-    }
-
-    return body;
-}
+ ASTNode Parser::parseBody()
+ {
+     while (peek().type == "LINE_BREAK")
+     {
+         consume("LINE_BREAK");
+     }
+ 
+     consume("OPEN_CURLY_BRACKET");
+     ASTNode body("BODY");
+ 
+     while (peek().type != "CLOSE_CURLY_BRACKET")
+     {
+         if (peek().type == "LINE_BREAK")
+         {
+             consume("LINE_BREAK");
+         }
+         else if (peek().type == "RETURN")
+         {
+             consume("RETURN");
+             ASTNode Return("RETURN");
+             ASTNode returnExpression = parseExpression();
+             Return.children.push_back(returnExpression);
+             body.children.push_back(Return);
+         }
+         else
+         {
+             ASTNode statement = parseStatement();
+             body.children.push_back(statement);
+         }
+     }
+ 
+     consume("CLOSE_CURLY_BRACKET");
+ 
+     while (peek().type == "LINE_BREAK")
+     {
+         consume("LINE_BREAK");
+     }
+ 
+     return body;
+ }
+ 


### PR DESCRIPTION
Moved the parsing of RETURN statement which into the main while loop which was previously out of the loop due to which unexpected RETURN token error was coming.